### PR TITLE
update navigation

### DIFF
--- a/script/embed.js
+++ b/script/embed.js
@@ -10,14 +10,10 @@ urlIn.onkeydown =
 		}
 	}
 
-vidEl.onkeydown =
+document.onkeydown =
 	function(g) {
 		if (g.keyCode == 27) {
-			vidEl.src = '';
-			vidEl.style.display = 'none';
-			window.location.href = window.location.href.split('?')[0];
-			getUrl(urlParam);
-			siteCont.style.display = 'flex';
+			history.back();
 		}
 	}
 

--- a/script/embed.js
+++ b/script/embed.js
@@ -13,7 +13,10 @@ urlIn.onkeydown =
 document.onkeydown =
 	function(g) {
 		if (g.keyCode == 27) {
-			history.back();
+			setTimeout(function(){
+				// Timeout is to send this to the bottom of the stack
+				window.location.href = window.location.href.split('?')[0];
+			}, 0);
 		}
 	}
 


### PR DESCRIPTION
if we bind the keydown to the video element, when we first navigate the video is not focused. Also if we're navigating (window.location.href navigates)  there's no need to do all of that style logic, so why not just go back?

If you would use some sort of script to transform discord messages into URLs pointing to this website, what "Should" happen when you press escape? Just navigate to the base URL? If you want to navigate to the base URL, just call window.location.href instead of history.back.

The issue around the page seemingly getting stuck can be replicated by setting a very slow network speed.